### PR TITLE
DO NOT MERGE - Add Input For Premake Version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,12 @@
-name: 'Setup premake'
-description: 'Install premake'
+name: 'Setup Premake'
+description: 'Install Premake'
 branding:
   icon: 'box'
   color: 'red'
+inputs:
+  version:
+    description: Version of Premake to set up
+    required: true
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -2,14 +2,15 @@ const core = require("@actions/core")
 const tc = require("@actions/tool-cache")
 
 async function main() {
-    path = "https://github.com/premake/premake-core/releases/download/"
-    version = "5.0.0-alpha16"
-    common = path + "v" + version + "/premake-" + version
-    if (process.platform == "win32") {
+    const path = "https://github.com/premake/premake-core/releases/download/"
+    const version = core.getInput('version', { required: true })
+    const platform = core.getInput('platform', { required: true })
+    const common = path + "v" + version + "/premake-" + version
+    if (platform == "win32") {
         const premake = await tc.downloadTool(common + "-windows.zip")
         await tc.extractZip(premake, '.premake')
     }
-    else if (process.platform == "darwin") {
+    else if (platform == "darwin") {
         const premake = await tc.downloadTool(common + "-macosx.tar.gz")
         await tc.extractTar(premake, '.premake')
     }

--- a/index.js
+++ b/index.js
@@ -6,18 +6,18 @@ async function main() {
     const version = core.getInput('version', { required: true })
     const common = path + "v" + version + "/premake-" + version
     if (process.platform == "win32") {
-        const premake = await tc.downloadTool(common + "-windows.zip")
         core.setFailed("win32" + common)
+        const premake = await tc.downloadTool(common + "-windows.zip")
         await tc.extractZip(premake, '.premake')
     }
     else if (process.platform == "darwin") {
-        const premake = await tc.downloadTool(common + "-macosx.tar.gz")
         core.setFailed("darwin" + common)
+        const premake = await tc.downloadTool(common + "-macosx.tar.gz")
         await tc.extractTar(premake, '.premake')
     }
     else {
-        const premake = await tc.downloadTool(common + "-linux.tar.gz")
         core.setFailed("linux" + common)
+        const premake = await tc.downloadTool(common + "-linux.tar.gz")
         await tc.extractTar(premake, '.premake')
     }
     core.addPath(".premake")

--- a/index.js
+++ b/index.js
@@ -7,17 +7,17 @@ async function main() {
     const common = path + "v" + version + "/premake-" + version
     if (process.platform == "win32") {
         const premake = await tc.downloadTool(common + "-windows.zip")
-        core.info("win32" + common)
+        core.setFailed("win32" + common)
         await tc.extractZip(premake, '.premake')
     }
     else if (process.platform == "darwin") {
         const premake = await tc.downloadTool(common + "-macosx.tar.gz")
-        core.info("darwin" + common)
+        core.setFailed("darwin" + common)
         await tc.extractTar(premake, '.premake')
     }
     else {
         const premake = await tc.downloadTool(common + "-linux.tar.gz")
-        core.info("linux" + common)
+        core.setFailed("linux" + common)
         await tc.extractTar(premake, '.premake')
     }
     core.addPath(".premake")

--- a/index.js
+++ b/index.js
@@ -4,13 +4,12 @@ const tc = require("@actions/tool-cache")
 async function main() {
     const path = "https://github.com/premake/premake-core/releases/download/"
     const version = core.getInput('version', { required: true })
-    const platform = core.getInput('platform', { required: true })
     const common = path + "v" + version + "/premake-" + version
-    if (platform == "win32") {
+    if (process.platform == "win32") {
         const premake = await tc.downloadTool(common + "-windows.zip")
         await tc.extractZip(premake, '.premake')
     }
-    else if (platform == "darwin") {
+    else if (process.platform == "darwin") {
         const premake = await tc.downloadTool(common + "-macosx.tar.gz")
         await tc.extractTar(premake, '.premake')
     }

--- a/index.js
+++ b/index.js
@@ -7,14 +7,17 @@ async function main() {
     const common = path + "v" + version + "/premake-" + version
     if (process.platform == "win32") {
         const premake = await tc.downloadTool(common + "-windows.zip")
+        core.info("win32" + common)
         await tc.extractZip(premake, '.premake')
     }
     else if (process.platform == "darwin") {
         const premake = await tc.downloadTool(common + "-macosx.tar.gz")
+        core.info("darwin" + common)
         await tc.extractTar(premake, '.premake')
     }
     else {
         const premake = await tc.downloadTool(common + "-linux.tar.gz")
+        core.info("linux" + common)
         await tc.extractTar(premake, '.premake')
     }
     core.addPath(".premake")


### PR DESCRIPTION
This is merely a proposal; I don't want to spend time right now reverting the random debug  stuff I was doing. You should seriously add a Premake version input instead of having it embedded in the script. You could have it not required and have a default in the action.yml for the latest version, though. I won't be updating this pull request further, this is up to you to implement.

Ignore the "platform" input I had added in the first commit. Adding a platform input isn't very useful.