### PR TITLE
Add path input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   version:
     description: 'Premake version'
     required: true
+  path:
+    description: 'Premake path'
+    required: false
+    default: '.premake'
 branding:
   icon: 'box'
   color: 'red'

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const path = require("path")
 async function main() {
     const version = core.getInput('version', { required: true })
     const userPath = core.getInput('path', { required: false })
+    if (userPath[0] == '/' || userPath[0] == '~') {
+        throw new Error("Path must be relative to the workspace")
+    }
     const pathPrefix = "https://github.com/premake/premake-core/releases/download/" + "v" + version + "/premake-" + version
     const premakePath = path.join(process.env.GITHUB_WORKSPACE, userPath)
     if (process.platform == "win32") {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ async function main() {
     const version = core.getInput('version', { required: true })
     const userPath = core.getInput('path', { required: false })
     const pathPrefix = "https://github.com/premake/premake-core/releases/download/" + "v" + version + "/premake-" + version
-    const premakePath = path.join(process.env.GITHUB_WORKSPACE, userPath);;
+    const premakePath = path.join(process.env.GITHUB_WORKSPACE, userPath)
     if (process.platform == "win32") {
         const premake = await tc.downloadTool(pathPrefix + "-windows.zip")
         await tc.extractZip(premake, premakePath)

--- a/index.js
+++ b/index.js
@@ -4,8 +4,9 @@ const path = require("path")
 
 async function main() {
     const version = core.getInput('version', { required: true })
+    const userPath = core.getInput('path', { required: false })
     const pathPrefix = "https://github.com/premake/premake-core/releases/download/" + "v" + version + "/premake-" + version
-    const premakePath = path.join(process.env.GITHUB_WORKSPACE, ".premake")
+    const premakePath = path.join(process.env.GITHUB_WORKSPACE, userPath);;
     if (process.platform == "win32") {
         const premake = await tc.downloadTool(pathPrefix + "-windows.zip")
         await tc.extractZip(premake, premakePath)


### PR DESCRIPTION
Currently, premake is always put into ".premake", with no option to change this.
Made a small edit which adds an input which will change the path premake is put at.

Tested on windows, self hosted runner.