### PR TITLE
Upgrade to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ branding:
   icon: 'box'
   color: 'red'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

GitHub Actions runners have started throwing a deprecation warning, so it may be good to upgrade. Untested, let's have CI test it.